### PR TITLE
Show warning for missing `<meta>` tag

### DIFF
--- a/addon/utils/get-asset-map-data.js
+++ b/addon/utils/get-asset-map-data.js
@@ -6,7 +6,13 @@ export default function getAssetMapData() {
     return assetMap.default;
   }
 
-  const assetMapString = document.querySelector("meta[name='ember-cli-ifa:assetMap']").content;
+  let metaTag = document.querySelector("meta[name='ember-cli-ifa:assetMap']");
+  if (!metaTag) {
+    console.warn('<meta name="ember-cli-ifa:assetMap"> tag is missing.');
+    return;
+  }
+
+  const assetMapString = metaTag.content;
   if (!assetMapString) {
     return;
   }


### PR DESCRIPTION
When the ember-cli-storybook addon is used there is no meta tag since it is currently generating a different HTML file that does not contain it. While it is okay for ember-cli-ifa to not work correctly in those cases we shouldn't crash the app, but instead show a warning indicating that the addon might not work as expected. Since fingerprinting and ember-cli-ifa are usually only enabled in production builds and ember-cli-storybook is aimed more at development builds that seems like a reasonable tradeoff until ember-cli-storybook can fix how it builds the HTML file.

**tl;dr** this adds basic compatibility with ember-cli-storybook