### PR TITLE
Check for ember-engine compatability

### DIFF
--- a/addon/initializers/asset-map.js
+++ b/addon/initializers/asset-map.js
@@ -19,7 +19,10 @@ export function initialize(app) {
     });
     app.register('service:asset-map', AssetMap);
   } else {
-    app.deferReadiness();
+    
+    if (typeof app.deferReadiness === "function") {
+      app.deferReadiness();
+    }
 
     const promise = fetch(assetMapFile).then(response => response.json());
 
@@ -37,7 +40,9 @@ export function initialize(app) {
       console.error('Failed to register service:asset-map', err);
     })
     .finally(() => {
-      app.advanceReadiness();
+      if (typeof app.advanceReadiness === "function") {
+        app.advanceReadiness();
+      }
     });
   }
 }

--- a/addon/initializers/asset-map.js
+++ b/addon/initializers/asset-map.js
@@ -35,11 +35,12 @@ export function initialize(app) {
     })
     .then(() => {
       app.register('service:asset-map', AssetMap);
+      if (typeof app.advanceReadiness === "function") {
+        app.advanceReadiness();
+      }
     })
     .catch((err) => {
       console.error('Failed to register service:asset-map', err);
-    })
-    .finally(() => {
       if (typeof app.advanceReadiness === "function") {
         app.advanceReadiness();
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-ifa",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Inject fingerprinted assetMap.json file into your app and provide initializer, service, and helper to dynamically reference fingerprinted assets.",
   "directories": {
     "doc": "doc",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "asset-map"
   ],
   "dependencies": {
-    "ember-cli-babel": "^6.11.0"
+    "ember-cli-babel": "^7.11.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-ifa",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Inject fingerprinted assetMap.json file into your app and provide initializer, service, and helper to dynamically reference fingerprinted assets.",
   "directories": {
     "doc": "doc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-ifa",
-  "version": "0.9.2",
+  "version": "0.9.4",
   "description": "Inject fingerprinted assetMap.json file into your app and provide initializer, service, and helper to dynamically reference fingerprinted assets.",
   "directories": {
     "doc": "doc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-ifa",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Inject fingerprinted assetMap.json file into your app and provide initializer, service, and helper to dynamically reference fingerprinted assets.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
In an ember-engine we do not have `deferReadiness` and `advanceReadiness`. We check for the existence and only execute when in an ember app.