### PR TITLE
Fix error - Inject empty meta tag when addon not enabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,11 +43,11 @@ module.exports = {
   },
 
   /**
-   * By default, during runtime the asset-map service reads the asset map
+   * By default, during runtime, the asset-map service reads the asset map
    * information from a meta tag on the index.html. As we do not have access to
    * global `document` when running in fastboot, we need to implement a
    * different way to access this asset-map information. See
-   * `get-asset-map-data` where we require the `asset-map` module taht is
+   * `get-asset-map-data` where we require the `asset-map` module that is
    * generated in the postBuild() below.
    */
   updateFastBootManifest(manifest) {

--- a/index.js
+++ b/index.js
@@ -35,6 +35,10 @@ module.exports = {
       return;
     }
 
+    if (!this._config().enabled) {
+      return '<meta name="ember-cli-ifa:assetMap">';
+    }
+
     return `<meta name="ember-cli-ifa:assetMap" content="${MetaPlaceholder}">`;
   },
 
@@ -55,10 +59,7 @@ module.exports = {
   postBuild(build) {
     this._super.included.apply(this, arguments);
 
-    const env = process.env.EMBER_ENV;
-    const ifaConfig = this.project.config(env).ifa;
-
-    if (!ifaConfig.enabled) {
+    if (!this._config().enabled) {
       return;
     }
 
@@ -85,10 +86,10 @@ module.exports = {
 
     // When using fastboot, always use the inline form
     // As ajax is not so easily possible there
-    if (!ifaConfig.inline && this._isFastBoot) {
+    if (!this._config().inline && this._isFastBoot) {
       this.ui.writeLine('When running fastboot, ember-cli-ifa is forced into inline mode.');
     }
-    const inline = ifaConfig.inline || this._isFastBoot;
+    const inline = this._config().inline || this._isFastBoot;
 
     let assetMap;
     if (inline && fs.existsSync(assetFileNamePath)) {
@@ -118,5 +119,10 @@ module.exports = {
     if (fs.existsSync(testIndexPath)) {
       replacePlaceholder(testIndexPath, assetMap);
     }
+  },
+
+  _config() {
+    const env = process.env.EMBER_ENV;
+    return this.project.config(env).ifa;
   },
 };


### PR DESCRIPTION
Since the update from `0.7.0`  to `0.9.0`, I've been getting the following error in environments where the `ember-cli-ifa` is **not** enabled. 

<img width="700" alt="Leadfeeder - Loading  2020-01-29 15-18-29" src="https://user-images.githubusercontent.com/1078185/73398183-9d59c100-42aa-11ea-9d54-c304a7ea7eb2.png">

After digging through the source, I discovered that the `meta` tag is[ added regardless](https://github.com/adopted-ember-addons/ember-cli-ifa/blob/master/index.js#L33) of whether the addon is enabled or not. Then, the function `getAssetMapData` tries to [parse the placeholder](https://github.com/adopted-ember-addons/ember-cli-ifa/blob/master/addon/utils/get-asset-map-data.js#L17) `__ember-cli-ifa__AssetMapPlaceholder__` that never gets replaced as the addon is not enabled. 

I've modified the part where the meta tag gets injected. It injects empty tag without the placeholder which causes an early return in function that parses JSON but doesn't trigger the missing meta warning. 