### PR TITLE
Do not run initializer if in an engine

### DIFF
--- a/addon/initializers/asset-map.js
+++ b/addon/initializers/asset-map.js
@@ -2,8 +2,14 @@ import RSVP from 'rsvp';
 import AssetMap from '../services/asset-map';
 import { typeOf as getTypeOf } from '@ember/utils';
 import getAssetMapData from 'ember-cli-ifa/utils/get-asset-map-data';
+import Application from '@ember/application';
 
 export function initialize(app) {
+  // If app is not an Ember Application, we are likely running an engine, which does not have `deferReadiness` or `advanceReadiness` so skip running this.
+  if (!(app instanceof Application)) {
+    return;
+  }
+
   let assetMapFile = getAssetMapData();
 
   if (!assetMapFile) {


### PR DESCRIPTION
Perhaps we also want to document this some, but I think we don't want to run this in an engine, correct? If we run in the host app, and share the `assetMap` service with the engine, I think it works?